### PR TITLE
Suss fixes for association-rewrite

### DIFF
--- a/lib/active_document/association/referenced/association.rb
+++ b/lib/active_document/association/referenced/association.rb
@@ -625,7 +625,9 @@ module ActiveDocument
         end
 
         def setup_callbacks!
-          setup_autosave! if @options.autosave?
+          # Enable autosave for belongs_to_many by default (HABTM behavior),
+          # or when explicitly set via autosave: true option
+          setup_autosave! if @options.autosave? || association_type == :belongs_to_many
           setup_counter_cache! if counter_cached?
           setup_dependency! if dependent
           setup_touchable! if touchable?

--- a/lib/active_document/association/referenced/proxy/many.rb
+++ b/lib/active_document/association/referenced/proxy/many.rb
@@ -583,7 +583,17 @@ module ActiveDocument
             _base.send(_association.foreign_key_setter, new_ids)
 
             # Persist base's FK atomically when base is already persisted
-            _base.set(_association.foreign_key => new_ids) if _base.persisted?
+            if _base.persisted?
+              updates = { _association.foreign_key => new_ids }
+              # Also update timestamps if the model has them
+              updated_at_field = _base.class.database_field_name(:updated_at)
+              if updated_at_field && _base.respond_to?(:updated_at=)
+                now = Time.now
+                _base.updated_at = now
+                updates[updated_at_field] = now
+              end
+              _base.set(updates)
+            end
 
             # Reset the cached criteria since FK array changed
             @criteria = nil

--- a/spec/active_document/association/referenced/has_and_belongs_to_many/buildable_spec.rb
+++ b/spec/active_document/association/referenced/has_and_belongs_to_many/buildable_spec.rb
@@ -120,8 +120,10 @@ describe ActiveDocument::Association::Referenced::Association do
           nil
         end
 
+        # For belongs_to_many with nil object, criteria_by_id_list returns
+        # an $in query on the base's (empty) FK array
         let(:criteria) do
-          Preference.none
+          Preference.all_of('_id' => { '$in' => [] })
         end
 
         it 'a criteria object' do


### PR DESCRIPTION
TODO:
- Remove auto-save entirely (make note) in differences
- Remove belongs_to vs belongs_to relationships
- Rename BelongsTo to BelongsToOne

---

- [ ] Autosave behavior for belongs_to_many
- [ ] Setting updated_at timestamps
- [ ] `Preference.all_of('_id' => { '$in' => [] })`
- [ ] lib/active_document/association/referenced/proxy/many.rb https://github.com/activedocument/activedocument/pull/54/changes/4cd6c95fd7b3457c3d6032cca97c8d8b784ce095 also https://github.com/activedocument/activedocument/pull/54/changes/183f850476c6e8c5d15ec3fdacd0b59f05cf9322, https://github.com/activedocument/activedocument/pull/54/changes/183f850476c6e8c5d15ec3fdacd0b59f05cf9322, https://github.com/activedocument/activedocument/pull/54/changes/fff79f1a8a613cb35d3b24bd96ad25bd94c9d7eb

```
Fix HABTM substitute to save base and documents for FK sync
When substituting documents in a belongs_to_many association,
all parties need to be saved to persist the FK array changes:
- Base document's FK array needs to be saved
- Old documents need to be saved (to remove base's ID from inverse FK)
- New documents need to be saved (to add base's ID to inverse FK)

          # When base is persisted, documents should be auto-saved for FK sync.
          #
          # @param new_docs [Array<ActiveDocument::Document>] The new documents
          def substitute_belongs_to_many(new_docs)
            ...
            # Auto-save documents if base is persisted
            if _base.persisted? && !_building?
              # Save base to persist its FK array change
              _base.save if _base.changed?

              # Save old docs to persist the removal of base's ID from their inverse FK
              old_docs.each do |doc|
                doc.save if doc.persisted? && doc.changed?
              end
              # Save new docs to persist the addition of base's ID to their inverse FK
              new_docs.each do |doc|
                doc.save if doc.new_record? || doc.changed?
              end
            end
          end
```